### PR TITLE
Bootstrapped Demo: Remove invalid stackings

### DIFF
--- a/01_subscription/saved_views/monthly_recurring_revenue.yml
+++ b/01_subscription/saved_views/monthly_recurring_revenue.yml
@@ -16,5 +16,4 @@ data:
 visualization:
   chartType: line
   showOther: true
-  stack: unstack
 

--- a/01_subscription/saved_views/net_new_customers.yml
+++ b/01_subscription/saved_views/net_new_customers.yml
@@ -17,6 +17,5 @@ data:
 visualization:
   chartType: bar
   showOther: true
-  stack: unstack
   showAxisLabels: true
 

--- a/01_subscription/saved_views/new_and_churned_customers.yml
+++ b/01_subscription/saved_views/new_and_churned_customers.yml
@@ -25,6 +25,5 @@ data:
 visualization:
   chartType: bar
   showOther: true
-  stack: stack
   showAxisLabels: true
 

--- a/01_subscription/saved_views/number_of_customers.yml
+++ b/01_subscription/saved_views/number_of_customers.yml
@@ -16,5 +16,4 @@ data:
 visualization:
   chartType: line
   showOther: true
-  stack: unstack
 


### PR DESCRIPTION
It isn't meaningful to encode stacks into a chart without a series.
**This PR affects the bootstrapped demos for new demo projects in the app.**